### PR TITLE
Allow referencing schemas by {mod, func}, defining them within funcs

### DIFF
--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -102,18 +102,32 @@ defmodule OpenApiSpex.Operation do
         required: false,
         schema: %OpenApiSpex.Schema{enum: ["pending", "in_progress", "completed"], type: :string}
       }
+
+      iex> Operation.parameter(
+      ...>   :status,
+      ...>   :query,
+      ...>   {Schemas, :entity_status},
+      ...>   "The status of an entity"
+      ...> )
+      %OpenApiSpex.Parameter{
+        name: :status,
+        in: :query,
+        description: "The status of an entity",
+        required: false,
+        schema: {Schemas, :entity_status}
+      }
   """
   @spec parameter(
           name :: atom,
           location :: Parameter.location(),
-          type :: Reference.t() | Schema.t() | Parameter.type() | atom(),
+          type :: Reference.t() | Schema.t() | Parameter.type() | atom() | Schema.func_ref(),
           description :: String.t(),
           opts :: keyword
         ) :: Parameter.t()
   def parameter(name, location, type, description, opts \\ [])
       when is_atom(name) and
              is_atom(location) and
-             (is_map(type) or is_atom(type)) and
+             (is_map(type) or is_atom(type) or is_tuple(type)) and
              is_binary(description) and
              is_list(opts) do
     params =

--- a/lib/open_api_spex/parameter.ex
+++ b/lib/open_api_spex/parameter.ex
@@ -65,7 +65,7 @@ defmodule OpenApiSpex.Parameter do
           style: style | nil,
           explode: boolean | nil,
           allowReserved: boolean | nil,
-          schema: Schema.t() | Reference.t() | atom | nil,
+          schema: Schema.t() | Reference.t() | atom | Schema.func_ref() | nil,
           example: any,
           examples: %{String.t() => Example.t() | Reference.t()} | nil,
           content: %{String.t() => MediaType.t()} | nil,
@@ -78,7 +78,7 @@ defmodule OpenApiSpex.Parameter do
   @doc """
   Sets the schema for a parameter from a simple type, reference or Schema
   """
-  @spec put_schema(t, Reference.t() | Schema.t() | type) :: t
+  @spec put_schema(t, Reference.t() | Schema.t() | Schema.func_ref() | type) :: t
   def put_schema(parameter = %Parameter{}, type = %Reference{}) do
     %{parameter | schema: type}
   end
@@ -93,6 +93,11 @@ defmodule OpenApiSpex.Parameter do
   end
 
   def put_schema(parameter = %Parameter{}, type) when is_atom(type) do
+    %{parameter | schema: type}
+  end
+
+  def put_schema(parameter = %Parameter{}, {module, function} = type)
+      when is_atom(module) and is_atom(function) do
     %{parameter | schema: type}
   end
 

--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -263,6 +263,8 @@ defmodule OpenApiSpex.Schema do
   """
   @type data_type :: :string | :number | :integer | :boolean | :array | :object
 
+  @type func_ref :: {module, atom}
+
   @typedoc """
   Global schemas lookup by name.
   """
@@ -363,7 +365,7 @@ defmodule OpenApiSpex.Schema do
         assert ...
       end
   """
-  @spec example(schema :: Schema.t() | module | Reference.t()) ::
+  @spec example(schema :: Schema.t() | module | Reference.t(), func_ref) ::
           map | String.t() | number | boolean
   def example(%Schema{example: example} = schema) when not is_nil(example) do
     schema.example
@@ -423,6 +425,10 @@ defmodule OpenApiSpex.Schema do
   def example(%Schema{type: :number} = s), do: example_for(s, :number)
   def example(%Schema{type: :boolean}), do: false
   def example(schema_module) when is_atom(schema_module), do: example(schema_module.schema())
+
+  def example({module, function}) when is_atom(module) and is_atom(function),
+    do: example(apply(module, function, []))
+
   def example(_schema), do: nil
 
   @doc """
@@ -518,6 +524,10 @@ defmodule OpenApiSpex.Schema do
   end
 
   defp default(schema_module) when is_atom(schema_module), do: schema_module.schema().default
+
+  defp default({module, function}) when is_atom(module) and is_atom(function),
+    do: apply(module, function, []).default
+
   defp default(%{default: default}), do: default
   defp default(%Reference{}), do: nil
 

--- a/lib/open_api_spex/schema_resolver.ex
+++ b/lib/open_api_spex/schema_resolver.ex
@@ -198,17 +198,7 @@ defmodule OpenApiSpex.SchemaResolver do
   end
 
   defp resolve_schema_modules_from_schema(schema, schemas) when is_atom(schema) do
-    title = schema.schema().title
-
-    new_schemas =
-      if Map.has_key?(schemas, title) do
-        schemas
-      else
-        {new_schema, schemas} = resolve_schema_modules_from_schema(schema.schema(), schemas)
-        Map.put(schemas, title, new_schema)
-      end
-
-    {%Reference{"$ref": "#/components/schemas/#{title}"}, new_schemas}
+    resolve_schema_modules_from_schema({schema, :schema}, schemas)
   end
 
   defp resolve_schema_modules_from_schema({module, func}, schemas)

--- a/lib/open_api_spex/schema_resolver.ex
+++ b/lib/open_api_spex/schema_resolver.ex
@@ -211,6 +211,22 @@ defmodule OpenApiSpex.SchemaResolver do
     {%Reference{"$ref": "#/components/schemas/#{title}"}, new_schemas}
   end
 
+  defp resolve_schema_modules_from_schema({module, func}, schemas)
+       when is_atom(module) and is_atom(func) do
+    schema = apply(module, func, [])
+    title = schema.title
+
+    new_schemas =
+      if Map.has_key?(schemas, title) do
+        schemas
+      else
+        {new_schema, schemas} = resolve_schema_modules_from_schema(schema, schemas)
+        Map.put(schemas, title, new_schema)
+      end
+
+    {%Reference{"$ref": "#/components/schemas/#{title}"}, new_schemas}
+  end
+
   defp resolve_schema_modules_from_schema(schema = %Schema{title: title}, schemas) do
     schemas =
       if is_nil(title) do

--- a/test/schema_resolver_test.exs
+++ b/test/schema_resolver_test.exs
@@ -153,6 +153,25 @@ defmodule OpenApiSpex.SchemaResolverTest do
               }
             }
           }
+        },
+        "/api/credit-cards" => %PathItem{
+          post: %Operation{
+            description: "Add a new credit card number",
+            operationId: "CreditCardController.create",
+            requestBody: %RequestBody{
+              required: true,
+              content: %{
+                "application/json" => %MediaType{
+                  schema: {OpenApiSpexTest.Schemas.FuncRefs, :credit_card_number}
+                }
+              }
+            },
+            responses: %{
+              201 => %Response{
+                description: "Number added"
+              }
+            }
+          }
         }
       }
     }
@@ -188,7 +207,8 @@ defmodule OpenApiSpex.SchemaResolverTest do
              "DirectDebitPaymentDetails" => %Schema{},
              "PetAppointmentRequest" => %Schema{},
              "TrainingAppointment" => %Schema{},
-             "GroomingAppointment" => %Schema{}
+             "GroomingAppointment" => %Schema{},
+             "CreditCardNumber" => %Schema{}
            } = resolved.components.schemas
 
     get_friends = resolved.paths["/api/users/{id}/friends"].get

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -268,6 +268,24 @@ defmodule OpenApiSpex.SchemaTest do
 
       assert Schema.example(Foo) == %{bar: %{baz: 2}, foo: "1"}
     end
+
+    test "example for func_ref" do
+      defmodule Baz do
+        def baz do
+          %OpenApiSpex.Schema{
+            type: :object,
+            properties: %{
+              foo: %Schema{
+                type: :string,
+                example: "42"
+              }
+            }
+          }
+        end
+      end
+
+      assert Schema.example({Baz, :baz}) == %{foo: "42"}
+    end
   end
 
   describe "example/2" do

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -3,6 +3,12 @@ defmodule OpenApiSpexTest.Schemas do
   alias OpenApiSpex.Reference
   alias OpenApiSpex.Schema
 
+  defmodule FuncRefs do
+    def credit_card_number do
+      %Schema{title: "CreditCardNumber", type: :string, description: "Credit card number"}
+    end
+  end
+
   defmodule Helper do
     def prepare_struct([%Reference{"$ref": "#/components/schemas/" <> name} | tail]) do
       schema =
@@ -234,7 +240,7 @@ defmodule OpenApiSpexTest.Schemas do
       description: "Payment details when using credit-card method",
       type: :object,
       properties: %{
-        credit_card_number: %Schema{type: :string, description: "Credit card number"},
+        credit_card_number: {OpenApiSpexTest.Schemas.FuncRefs, :credit_card_number},
         name_on_card: %Schema{type: :string, description: "Name as appears on card"},
         expiry: %Schema{type: :string, description: "4 digit expiry MMYY"}
       },


### PR DESCRIPTION
* Allows for defined-within-functions schemas
* Reference-able via tuple syntax `{module, func}`
* This has serious compilation implications in a codebase like ours: ~10x speedup
* This means schemas defined within funcs are of course not defined as structs.