### PR TITLE
Fix typespecs

### DIFF
--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -398,7 +398,7 @@ defmodule OpenApiSpex do
   @doc """
   Resolve a schema or reference to a schema.
   """
-  @spec resolve_schema(Schema.t() | Reference.t() | module, Components.schemas_map()) ::
+  @spec resolve_schema(Schema.schema_reference(), Components.schemas_map()) ::
           Schema.t() | nil
   def resolve_schema(%Schema{} = schema, _), do: schema
   def resolve_schema(%Reference{} = ref, schemas), do: Reference.resolve_schema(ref, schemas)

--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -145,7 +145,7 @@ defmodule OpenApiSpex.Operation do
   @spec request_body(
           description :: String.t(),
           media_type :: String.t() | %{String.t() => Keyword.t() | MediaType.t()},
-          schema_ref :: Schema.t() | Reference.t() | module,
+          schema_ref :: Schema.schema_reference(),
           opts :: keyword
         ) :: RequestBody.t()
   def request_body(description, media_type, schema_ref, opts \\ []) do
@@ -173,7 +173,7 @@ defmodule OpenApiSpex.Operation do
   @spec response(
           description :: String.t(),
           media_type :: String.t() | %{String.t() => Keyword.t() | MediaType.t()} | nil,
-          schema_ref :: Schema.t() | Reference.t() | module | nil,
+          schema_ref :: Schema.schema_reference() | nil,
           opts :: keyword
         ) :: Response.t()
   def response(description, media_type, schema_ref, opts \\ []) do

--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -233,13 +233,13 @@ defmodule OpenApiSpex.Schema do
           required: [atom] | nil,
           enum: [any] | nil,
           type: data_type | nil,
-          allOf: [Schema.t() | Reference.t() | module] | nil,
-          oneOf: [Schema.t() | Reference.t() | module] | nil,
-          anyOf: [Schema.t() | Reference.t() | module] | nil,
-          not: Schema.t() | Reference.t() | module | nil,
-          items: Schema.t() | Reference.t() | module | nil,
-          properties: %{atom => Schema.t() | Reference.t() | module} | nil,
-          additionalProperties: boolean | Schema.t() | Reference.t() | module | nil,
+          allOf: [schema_reference()] | nil,
+          oneOf: [schema_reference()] | nil,
+          anyOf: [schema_reference()] | nil,
+          not: schema_reference() | nil,
+          items: schema_reference() | nil,
+          properties: %{atom => schema_reference()} | nil,
+          additionalProperties: boolean | schema_reference() | nil,
           description: String.t() | nil,
           format: String.t() | atom | nil,
           default: any,
@@ -264,6 +264,8 @@ defmodule OpenApiSpex.Schema do
   @type data_type :: :string | :number | :integer | :boolean | :array | :object
 
   @type func_ref :: {module, atom}
+
+  @type schema_reference :: Schema.t() | module | Reference.t() | func_ref
 
   @typedoc """
   Global schemas lookup by name.
@@ -365,7 +367,7 @@ defmodule OpenApiSpex.Schema do
         assert ...
       end
   """
-  @spec example(schema :: Schema.t() | module | Reference.t(), func_ref) ::
+  @spec example(schema :: schema_reference()) ::
           map | String.t() | number | boolean
   def example(%Schema{example: example} = schema) when not is_nil(example) do
     schema.example


### PR DESCRIPTION
Without these changes I got errors from dialyzer when using the `{module, function}` approach as reference for a schema property.