### PR TITLE
Resolve tuple ref discriminator mappings

### DIFF
--- a/lib/open_api_spex/schema_resolver.ex
+++ b/lib/open_api_spex/schema_resolver.ex
@@ -297,6 +297,12 @@ defmodule OpenApiSpex.SchemaResolver do
 
           {{key, path}, schemas}
 
+        {key, {module, function}}, schemas when is_atom(module) and is_atom(function) ->
+          {%Reference{"$ref": path}, schemas} =
+            resolve_schema_modules_from_schema({module, function}, schemas)
+
+          {{key, path}, schemas}
+
         {key, path}, schemas ->
           {{key, path}, schemas}
       end)

--- a/test/schema_resolver_test.exs
+++ b/test/schema_resolver_test.exs
@@ -197,6 +197,11 @@ defmodule OpenApiSpex.SchemaResolverTest do
                "grooming"
              ]
 
+    assert "#/components/schemas/NailClippingAppointment" =
+             resolved.components.schemas["PetAppointmentRequest"].discriminator.mapping[
+               "nail_clipping"
+             ]
+
     assert %{
              "UserRequest" => %Schema{},
              "UserResponse" => %Schema{},

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -639,6 +639,27 @@ defmodule OpenApiSpexTest.Schemas do
     })
   end
 
+  def nail_clipping_appointment do
+    %OpenApiSpex.Schema{
+      title: "NailClippingAppointment",
+      description: "Request for a nail clipping appointment",
+      type: :object,
+      allOf: [
+        AppointmentType,
+        %Schema{
+          type: :object,
+          properties: %{
+            length: %Schema{
+              description: "Length in mm of nails",
+              type: :integer
+            }
+          },
+          required: [:length]
+        }
+      ]
+    }
+  end
+
   defmodule PetAppointmentRequest do
     OpenApiSpex.schema(%{
       title: "PetAppointmentRequest",
@@ -652,7 +673,8 @@ defmodule OpenApiSpexTest.Schemas do
         propertyName: "appointment_type",
         mapping: %{
           "training" => TrainingAppointment,
-          "grooming" => GroomingAppointment
+          "grooming" => GroomingAppointment,
+          "nail_clipping" => {OpenApiSpexTest.Schemas, :nail_clipping_appointment}
         }
       }
     })


### PR DESCRIPTION
* With the introduction of `{module, function_name}` schema refs, we missed an instance (discriminator mappings) in correctly resolving them
* This fixes and tests