### PR TITLE
Fix Inspect implementation to use public API instead of private Inspect.Map functions

### DIFF
--- a/lib/open_api_spex/inspect/for_schema.ex
+++ b/lib/open_api_spex/inspect/for_schema.ex
@@ -1,4 +1,6 @@
 defimpl Inspect, for: OpenApiSpex.Schema do
+  import Inspect.Algebra
+
   def inspect(parameter, opts) do
     map =
       parameter
@@ -9,11 +11,9 @@ defimpl Inspect, for: OpenApiSpex.Schema do
       end)
       |> Map.new()
 
-    infos =
-      for %{field: field} = info <- OpenApiSpex.Schema.__info__(:struct),
-          Map.has_key?(map, field),
-          do: info
-
-    Inspect.Map.inspect(map, "OpenApiSpex.Schema", infos, opts)
+    # Note: We cannot use Inspect.Map.inspect/4 or Inspect.Map.inspect_as_struct/5
+    # because they are private functions in the Inspect.Map module and not part of
+    # the public API. Instead, we use Inspect.Algebra functions (concat, to_doc).
+    concat(["#OpenApiSpex.Schema<", to_doc(map, opts), ">"])
   end
 end


### PR DESCRIPTION
## Problem

When inspecting an  struct in IEx, an  is raised because the implementation was calling the private function `Inspect.Map.inspect/4`:

```elixir
iex(1)> %OpenApiSpex.Schema{type: :string}
#Inspect.Error<
  got UndefinedFunctionError with message:

      """
      function Inspect.Map.inspect/4 is undefined or private
      """

  while inspecting:

      %{
        type: :string,
        __struct__: OpenApiSpex.Schema,
        # ... (other fields)
      }

  Stacktrace:

    (elixir 1.19.2) Inspect.Map.inspect(%{type: :string}, "OpenApiSpex.Schema", ...)
    (elixir 1.19.2) lib/inspect/algebra.ex:401: Inspect.Algebra.to_doc_with_opts/2
    ...
```

The `Inspect.Map.inspect/4` and `Inspect.Map.inspect_as_struct/5` functions are private functions in the `Inspect.Map` module and are not part of Elixir's public API.

## Solution

Updated the `Inspect` implementation for `OpenApiSpex.Schema` to use the public `Inspect.Algebra` API instead:

- Use `Inspect.Algebra.concat/1` and `Inspect.Algebra.to_doc/2` functions
- Added a comment explaining why the private functions cannot be used

The struct now properly inspects in IEx without errors while maintaining a similar output format.

## Testing

Compiles without warnings:
```
mix compile --warnings-as-errors
```

Can now inspect schemas in IEx:
```elixir
iex> %OpenApiSpex.Schema{type: :string}
#OpenApiSpex.Schema<...>
```